### PR TITLE
Add missing Environment field Bug type template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/bug-issue.md
@@ -19,6 +19,7 @@ Check the following when creating an issue:
 
 ### Environment, URL, identifier
 
+<br />Environment: 
 <br />URL: 
 <br />Identifier: ``
 


### PR DESCRIPTION
<!--
Check the following when creating a pull request:
* Did you add a proper title?
  * Start with a verb e.g. _Fix_ or _Update_ (imperative mood)
  * Only a capital at the start of the title (except for brand names e.g. _GitHub_)
  * No punctuation
* Did you link it to the corresponding issue(s)?
* Did you follow https://keepachangelog.com/en/1.1.0/ for the description?
-->
**Issue:** _noticed when creating a bug_

### Added
- Missing `Environment` field Bug type template

<!--
### Changed
-

### Deprecated
-

### Removed
-

### Fixed
-

### Security
- 

## Additional context
-->
