### PR TITLE
Add documentation link checkboxes to the feature issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/feature-issue.md
@@ -27,7 +27,7 @@ Check the following when creating an issue:
 
 Documentation link:  
 
-<!-- Check off one of the following fields, do not remove this section -->
+<!-- Check off only one of the following fields, do not remove this section -->
 <!-- The second checkbox is only available when QA was involved in planning -->
 - [ ] I have provided the mandatory documentation link
 - [ ] No documentation link provided - this is a non-QAable sub-issue

--- a/.github/ISSUE_TEMPLATE/feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/feature-issue.md
@@ -31,7 +31,7 @@ Documentation link:
 <!-- The second checkbox is only available when QA was involved in planning -->
 - [ ] I have provided the mandatory documentation link
 - [ ] No documentation link provided - this is a non-QAable sub-issue
-- [ ] No documentation link provided - I will explain myself below
+- [ ] No documentation link provided - context will be provided below
 
 <!-- Notion links, Figma documents, screenshots, videos -->
 

--- a/.github/ISSUE_TEMPLATE/feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/feature-issue.md
@@ -24,7 +24,14 @@ Check the following when creating an issue:
 <!-- High level, leaving the details of affected areas and expected results in the testing instructions below -->
 
 ### Additional context
-*Feature Documentation Link:* 
+
+Documentation link:  
+
+<!-- Check off one of the following fields, do not remove this section -->
+<!-- The second checkbox is only available when QA was involved in planning -->
+- [ ] I have provided the mandatory documentation link
+- [ ] No documentation link provided - this is a non-QAable sub-issue 
+- [ ] No documentation link provided - I will explain myself below
 
 <!-- Notion links, Figma documents, screenshots, videos -->
 

--- a/.github/ISSUE_TEMPLATE/feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/feature-issue.md
@@ -30,7 +30,7 @@ Documentation link:
 <!-- Check off one of the following fields, do not remove this section -->
 <!-- The second checkbox is only available when QA was involved in planning -->
 - [ ] I have provided the mandatory documentation link
-- [ ] No documentation link provided - this is a non-QAable sub-issue 
+- [ ] No documentation link provided - this is a non-QAable sub-issue
 - [ ] No documentation link provided - I will explain myself below
 
 <!-- Notion links, Figma documents, screenshots, videos -->


### PR DESCRIPTION
### Added
- Checkboxes related to the documentation link to make the requirement more explicit.

---

## Additional context

After today's ZIM daily as well as follow up discussion with JDS, this PR is an attempt to address two matters:
- Remove the recurring daily reminder that documentation is of essence to QA.
- Relieve the QA column from sub tasks that not only are "No QA", but actually require no attention from QA (given they would provide no situational awareness context).

The reasoning for the latter is that QA wants to maintain situational awareness. However, it is not sustainable if all sub-issues pass through the QA column on the project board in GitHub. Therefore, if QA has been involved in planning (hence, they already have the context) and the sub-issue(s) are not QA'able until the parent issue is complete, the issue does not require a direct documentation link (it's mostly for engineering task tracking, really) and can be immediately moved to the Done column without passing through the QA column.

<img width="524" height="466" alt="image" src="https://github.com/user-attachments/assets/ddb41695-b2c6-40f6-8acc-1f85bb3ae333" />
