### PR TITLE
Remove "enhancement" label from features

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/feature-issue.md
@@ -2,7 +2,7 @@
 name: Feature issue
 about: When adding new features or improving existing features
 title: ''
-labels: enhancement
+labels: ''
 assignees: ''
 
 ---


### PR DESCRIPTION


<!--
Check the following when creating a pull request:
* Did you add a proper title?
  * Start with a verb e.g. _Fix_ or _Update_ (imperative mood)
  * Only a capital at the start of the title (except for brand names e.g. _GitHub_)
  * No punctuation
* Did you link it to the corresponding issue(s)?
* Did you follow https://keepachangelog.com/en/1.1.0/ for the description?
-->
**Issue:** N/A

### Removed
- 'enhancement' label which no longer exists in our projects

<!--
### Changed
-

### Deprecated
-

### Removed
-

### Fixed
-

### Security
- 

-->

## Additional context

We removed this label from our projects as it does not have a lot of value (since in theory, every change is an enhancement)

